### PR TITLE
Add mkdirp as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Ade Viankakrisna Fadlil",
   "license": "ISC",
   "dependencies": {
-    "find-cache-dir": "^0.1.1"
+    "find-cache-dir": "^0.1.1",
+    "mkdirp": "0.5.1"
   }
 }


### PR DESCRIPTION
Adds mkdirp as a dependency, to fix issues like https://github.com/MoOx/eslint-loader/issues/166

This will require a new version of loader-fs-cache to be released asap