### PR TITLE
fix prototype solution in dependent minimist package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "find-cache-dir": "^0.1.1",
-    "mkdirp": "0.5.1"
+    "mkdirp": "^0.5.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
please merge this PR to loosen the dependency on mkdir package to allow installation of the new version 0.5.3 that fixes its minimist dependency. Current version of minimist has a prototype pollution vulnerability (https://www.npmjs.com/advisories/1179 or https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764)

Afterwards please publish a new minor version to allow all other projects to pick up this fix (like eslint loader for vue)

Thanks,
Stefan Seide